### PR TITLE
Issue #74 -all/1 should not return prefixes 

### DIFF
--- a/lib/mix/tasks/triplex.migrations.ex
+++ b/lib/mix/tasks/triplex.migrations.ex
@@ -6,6 +6,8 @@ defmodule Mix.Tasks.Triplex.Migrations do
   alias Mix.Ecto
   alias Mix.Triplex, as: MTriplex
 
+  alias Triplex
+
   @shortdoc "Displays the repository migration status"
   @recursive true
 
@@ -57,7 +59,8 @@ defmodule Mix.Tasks.Triplex.Migrations do
 
   defp tenants_state(repo, migration_lists) do
     Enum.map_join(Triplex.all(repo), fn tenant ->
-      tenant_versions = Migrator.migrated_versions(repo, prefix: tenant)
+      tenant_versions = Migrator.migrated_versions(repo, prefix: Triplex.to_prefix(tenant))
+
       repo_status = repo_status(migration_lists, tenant_versions)
 
       """


### PR DESCRIPTION
Hi,

As per our discussion I have modified all/1 to strip the configured prefix. This will ensure that when the resulting list is passed to the migrate/2 function it will not add the prefix again before running any migrations.

I have also aligned the recording of tenants in MySql by ensuring the tenant has any configured prefix prepended to the tenant name before being added to the the table. This ensures that the MS and PG solutions work in the same way.

I have added one test to get all tenants and pass the list to migrate/2

Let me know if I have missed anything.

Andrew