### PR TITLE
move `timestamp/0` into Mix.Triplex

### DIFF
--- a/lib/mix/tasks/triplex.gen.migration.ex
+++ b/lib/mix/tasks/triplex.gen.migration.ex
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Triplex.Gen.Migration do
             |> Triplex.migrations_path()
             |> Path.relative_to(Project.app_path())
 
-          file = Path.join(path, "#{timestamp()}_#{Macro.underscore(name)}.exs")
+          file = Path.join(path, "#{Mix.Triplex.timestamp()}_#{Macro.underscore(name)}.exs")
           Generator.create_directory(path)
 
           assigns = [
@@ -73,11 +73,6 @@ defmodule Mix.Tasks.Triplex.Gen.Migration do
           )
       end
     end)
-  end
-
-  defp timestamp do
-    {{y, m, d}, {hh, mm, ss}} = :calendar.universal_time()
-    "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
   end
 
   defp pad(i), do: i |> to_string() |> String.pad_leading(2, "0")

--- a/lib/mix/tasks/triplex.mysql.install.ex
+++ b/lib/mix/tasks/triplex.mysql.install.ex
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Triplex.Mysql.Install do
       end
 
       path = Path.relative_to(Migrator.migrations_path(repo), Project.app_path())
-      file = Path.join(path, "#{timestamp()}_#{@migration_name}.exs")
+      file = Path.join(path, "#{Mix.Triplex.timestamp()}_#{@migration_name}.exs")
       Generator.create_directory(path)
 
       Generator.create_file(
@@ -43,11 +43,6 @@ defmodule Mix.Tasks.Triplex.Mysql.Install do
         )
       )
     end)
-  end
-
-  defp timestamp do
-    {{y, m, d}, {hh, mm, ss}} = :calendar.universal_time()
-    "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
   end
 
   defp pad(i), do: i |> to_string() |> String.pad_leading(2, "0")

--- a/lib/mix/triplex.ex
+++ b/lib/mix/triplex.ex
@@ -57,6 +57,14 @@ defmodule Mix.Triplex do
     path
   end
 
+  @doc """
+  Generates a nicely formatted timestamp
+  """
+  def timestamp() do
+    {{y, m, d}, {hh, mm, ss}} = :calendar.universal_time()
+    "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
+  end
+
   defp raise_missing_migrations(path, repo) do
     Mix.raise("""
     Could not find migrations directory #{inspect(path)}


### PR DESCRIPTION
This deduplicates the timestamp formatting function between the migration generator and MySQL install mix tasks.