### PR TITLE
feat(Triplex): Allow users to turn off logging of SQL queries

### DIFF
--- a/lib/triplex.ex
+++ b/lib/triplex.ex
@@ -284,7 +284,7 @@ defmodule Triplex do
   @doc """
   Returns all the tenants on the given `repo`.
   """
-  def all(repo \\ config().repo) do
+  def all(repo \\ config().repo, opts \\ []) do
     sql =
       case repo.__adapter__ do
         Ecto.Adapters.MyXQL ->
@@ -302,7 +302,7 @@ defmodule Triplex do
           """
       end
 
-    %{rows: result} = SQL.query!(repo, sql, [])
+    %{rows: result} = SQL.query!(repo, sql, [], opts)
 
     result
     |> List.flatten()


### PR DESCRIPTION
Every time `Triplex.all` is called it will log a SQL query to the console. This allows devs to turn that off by passing `log: false` as an option to the function.