### PR TITLE
Remove error from mix task `triplex.migrations`

### DIFF
--- a/lib/mix/tasks/triplex.migrations.ex
+++ b/lib/mix/tasks/triplex.migrations.ex
@@ -42,12 +42,12 @@ defmodule Mix.Tasks.Triplex.Migrations do
       Enum.map(repos, fn repo ->
         Ecto.ensure_repo(repo, args)
         MTriplex.ensure_tenant_migrations_path(repo)
-        {:ok, pid, _} = MTriplex.ensure_started(repo, all: true)
+        {:ok, _pid, _} = MTriplex.ensure_started(repo, all: true)
 
         migration_lists = migrations.(repo, Triplex.migrations_path(repo))
         tenants_state = tenants_state(repo, migration_lists)
 
-        pid && repo.stop(pid)
+        repo.stop()
 
         tenants_state
       end)


### PR DESCRIPTION
Running `mix triplex.migrations` results in an error.

The `stop` callback for `Ecto.Repo` no longer takes a `pid` argument as of Ecto 3.

https://hexdocs.pm/ecto/2.2.12/Ecto.Repo.html#c:stop/2
https://hexdocs.pm/ecto/Ecto.Repo.html#c:stop/1

This update matches a change from #61 to the same effect.